### PR TITLE
Finalize LiveEducationTest

### DIFF
--- a/src/main/java/pages/LiveEducationPage.java
+++ b/src/main/java/pages/LiveEducationPage.java
@@ -4,6 +4,7 @@ import data.Time;
 import org.openqa.selenium.WebDriver;
 import utils.LoggerUtils;
 
+import org.openqa.selenium.By;
 import static data.PageUrlPaths.lIVE_EDUCATION_PAGE;
 
 public class LiveEducationPage extends CommonPageClass {
@@ -17,5 +18,11 @@ public class LiveEducationPage extends CommonPageClass {
         waitForUrlChange(lIVE_EDUCATION_PAGE, Time.TIME_SHORTER);
         waitUntilPageIsReady(Time.TIME_SHORTER);
         return this;
+    }
+
+    public boolean isTextVisible(String text) {
+        LoggerUtils.log.debug("isTextVisible(" + text + ")");
+        By locator = By.xpath("//*[contains(text(), '" + text + "')]");
+        return isWebElementDisplayed(locator, Time.TIME_SHORTER);
     }
 }

--- a/src/test/java/tests/UI/LiveEducationTest.java
+++ b/src/test/java/tests/UI/LiveEducationTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import pages.CommonPageClass;
 import pages.HomePage;
 import pages.LiveEducationPage;
+import org.testng.Assert;
 import utils.DateTimeUtils;
 import utils.JavaScriptUtils;
 import utils.LoggerUtils;
@@ -50,37 +51,12 @@ public class LiveEducationTest extends BaseTestClass {
 
 
     @Test
-    public void test01() {
-        // On the Live Education Page
-        // No visible play button.
-        // No time indicator.
-        // No standard video controls (like play/pause or timeline).
-        // UI suggests it's scheduled for a future date (April 7 at 08:00 AM)
-        // Below it says: "Every weekday at 8:00 AM" → Could mean live-only event.
-
-       /*
-       {
-    "id": 19664174,
-    "metering": {
-        "seconds_remaining": 43200,
-        "seconds_max": 43200
-    },
-    "ingest": {
-        "rtmps_url": "rtmps:\/\/rtmp-global.cloud.vimeo.com:443\/live",
-        "height": null,
-        "width": null,
-        "status": 0,
-        "session_id": null,
-        "stream_ended_reason": null,
-        "start_time": null,
-        "scheduled_start_time": "2025-04-07T06:00:00+00:00"
-    },
-    "archive": {
-        "status": 0
-    }
-}
-        */
-
+    public void verifyScheduleTextIsVisible() {
+        String expectedText = "Every weekday at 8:00 AM";
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        boolean isDisplayed = liveEducationPage.isTextVisible(expectedText);
+        Assert.assertTrue(isDisplayed,
+                "Schedule text should be visible on Live Education page");
     }
 
 


### PR DESCRIPTION
## Summary
- improve LiveEducationTest by asserting schedule text
- add helper method `isTextVisible` in LiveEducationPage

## Testing
- `mvn -q -Dtest=LiveEducationTest test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_688baa27efd88323a7ffb8db327a894f