### PR TITLE
Refactor setup code in UI tests

### DIFF
--- a/src/test/java/tests/UI/BaseTestClass.java
+++ b/src/test/java/tests/UI/BaseTestClass.java
@@ -1,7 +1,11 @@
 package tests.UI;
 
 import org.openqa.selenium.WebDriver;
+import org.testng.ITestContext;
 import org.testng.ITestResult;
+import pages.CommonPageClass;
+import pages.HomePage;
+import data.Time;
 import utils.*;
 
 public abstract class BaseTestClass {
@@ -30,6 +34,23 @@ public abstract class BaseTestClass {
     }
     protected WebDriver setUp800x600Resolution() {
         return setUpDriverWithResolution("screen.resolution.small");
+    }
+
+    protected WebDriver prepareHomePage(ITestContext testContext, String testName) {
+        LoggerUtils.log.debug("[SETUP TEST] " + testName);
+        WebDriver driver = setUpMaxResolution();
+        testContext.setAttribute(testName + ".drivers", new WebDriver[]{driver});
+
+        HomePage homePage = new HomePage(driver);
+        CommonPageClass commonPageClass = new CommonPageClass(driver);
+        commonPageClass.isExpectedTitleDisplayed("Access Global Financial Markets and Start Trading | XM");
+        homePage.verifyHomePage();
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        homePage.clickAcceptCookies();
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        homePage.clickDiscoverMenu();
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        return driver;
     }
 
     protected void quitDriver(WebDriver driver) {

--- a/src/test/java/tests/UI/EconomicCalendarTests.java
+++ b/src/test/java/tests/UI/EconomicCalendarTests.java
@@ -7,7 +7,6 @@ import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import pages.CommonPageClass;
 import pages.EconomicCalendarPage;
 import pages.HomePage;
 import utils.DateTimeUtils;
@@ -19,23 +18,15 @@ public class EconomicCalendarTests extends BaseTestClass {
 
     private WebDriver driver;
     private final String sTestName = this.getClass().getName();
-    HomePage homePage = new HomePage(driver);
-    EconomicCalendarPage economicCalendarPage = new EconomicCalendarPage(driver);
+    HomePage homePage;
+    EconomicCalendarPage economicCalendarPage;
     JavaScriptUtils javaScriptUtils = new JavaScriptUtils();
 
     @BeforeMethod
     public void setUp(ITestContext testContext) {
-        LoggerUtils.log.debug("[SETUP TEST] " + sTestName);
-        driver = setUpMaxResolution();
-        testContext.setAttribute(sTestName + ".drivers", new WebDriver[]{driver});
-        CommonPageClass commonPageClass = new CommonPageClass(driver);
-        commonPageClass.isExpectedTitleDisplayed("Access Global Financial Markets and Start Trading | XM");
-        homePage.verifyHomePage();
-        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
-        homePage.clickAcceptCookies();
-        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
-        homePage.clickDiscoverMenu();
-        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        driver = prepareHomePage(testContext, sTestName);
+        homePage = new HomePage(driver);
+        economicCalendarPage = new EconomicCalendarPage(driver);
         homePage.clickEconomicCalendar();
         DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
         economicCalendarPage.verifyEconomicCalendarPage();

--- a/src/test/java/tests/UI/LiveEducationTest.java
+++ b/src/test/java/tests/UI/LiveEducationTest.java
@@ -7,7 +7,6 @@ import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import pages.CommonPageClass;
 import pages.HomePage;
 import pages.LiveEducationPage;
 import org.testng.Assert;
@@ -20,23 +19,15 @@ public class LiveEducationTest extends BaseTestClass {
     private WebDriver driver;
     private final String sTestName = this.getClass().getName();
     private boolean bCreated = false;
-    HomePage homePage = new HomePage(driver);
-    LiveEducationPage liveEducationPage = new LiveEducationPage(driver);
+    HomePage homePage;
+    LiveEducationPage liveEducationPage;
     JavaScriptUtils javaScriptUtils = new JavaScriptUtils();
 
     @BeforeMethod
     public void setUp(ITestContext testContext) {
-        LoggerUtils.log.debug("[SETUP TEST] " + sTestName);
-        driver = setUpMaxResolution();
-        testContext.setAttribute(sTestName + ".drivers", new WebDriver[]{driver});
-        CommonPageClass commonPageClass = new CommonPageClass(driver);
-        commonPageClass.isExpectedTitleDisplayed("Access Global Financial Markets and Start Trading | XM");
-        homePage.verifyHomePage();
-        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
-        homePage.clickAcceptCookies();
-        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
-        homePage.clickDiscoverMenu();
-        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        driver = prepareHomePage(testContext, sTestName);
+        homePage = new HomePage(driver);
+        liveEducationPage = new LiveEducationPage(driver);
         homePage.clickLiveEducation();
         DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
         liveEducationPage.verifyLiveEducationPage();


### PR DESCRIPTION
## Summary
- add `prepareHomePage` helper in `BaseTestClass`
- reuse helper in `EconomicCalendarTests` and `LiveEducationTest`
- instantiate page objects after driver initialization to avoid duplication

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688bac83c7b48323a90ec3b1116355b1