### PR TITLE
Add Facebook sign-up flow test

### DIFF
--- a/src/main/java/pages/facebook/FacebookHomePage.java
+++ b/src/main/java/pages/facebook/FacebookHomePage.java
@@ -1,0 +1,37 @@
+package pages.facebook;
+
+import data.Time;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import pages.CommonPageClass;
+import utils.LoggerUtils;
+
+public class FacebookHomePage extends CommonPageClass {
+
+    private static final String HOME_URL = "https://www.facebook.com/";
+
+    private final By createNewAccountBtn = By.xpath("//a[@data-testid='open-registration-form-button']");
+
+    public FacebookHomePage(WebDriver driver) {
+        super(driver);
+    }
+
+    public FacebookHomePage open(boolean verify) {
+        LoggerUtils.log.debug("open(" + HOME_URL + ")");
+        openUrl(HOME_URL);
+        if (verify) {
+            verifyHomePage();
+        }
+        return this;
+    }
+
+    public FacebookHomePage verifyHomePage() {
+        LoggerUtils.log.debug("verifyHomePage()");
+        waitUntilPageIsReady(Time.TIME_SHORTER);
+        return this;
+    }
+
+    public void clickCreateNewAccount() {
+        clickOnWebElement(getWebElement(createNewAccountBtn, Time.TIME_SHORTER));
+    }
+}

--- a/src/main/java/pages/facebook/FacebookSignUpPage.java
+++ b/src/main/java/pages/facebook/FacebookSignUpPage.java
@@ -1,0 +1,81 @@
+package pages.facebook;
+
+import data.Time;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import pages.CommonPageClass;
+import utils.LoggerUtils;
+
+public class FacebookSignUpPage extends CommonPageClass {
+
+    private final By firstNameInput = By.name("firstname");
+    private final By lastNameInput = By.name("lastname");
+    private final By emailInput = By.name("reg_email__");
+    private final By emailConfirmInput = By.name("reg_email_confirmation__");
+    private final By passwordInput = By.name("reg_passwd__");
+    private final By birthDaySelect = By.id("day");
+    private final By birthMonthSelect = By.id("month");
+    private final By birthYearSelect = By.id("year");
+    private final By femaleRadio = By.xpath("//input[@name='sex' and @value='1']");
+    private final By maleRadio = By.xpath("//input[@name='sex' and @value='2']");
+    private final By customRadio = By.xpath("//input[@name='sex' and @value='-1']");
+    private final By signUpButton = By.name("websubmit");
+
+    public FacebookSignUpPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public FacebookSignUpPage verifySignUpPage() {
+        LoggerUtils.log.debug("verifySignUpPage()");
+        waitUntilPageIsReady(Time.TIME_SHORTER);
+        return this;
+    }
+
+    public FacebookSignUpPage enterFirstName(String firstName) {
+        clearAndTypeTextToWebElement(getWebElement(firstNameInput, Time.TIME_SHORTER), firstName);
+        return this;
+    }
+
+    public FacebookSignUpPage enterLastName(String lastName) {
+        clearAndTypeTextToWebElement(getWebElement(lastNameInput, Time.TIME_SHORTER), lastName);
+        return this;
+    }
+
+    public FacebookSignUpPage enterEmail(String email) {
+        clearAndTypeTextToWebElement(getWebElement(emailInput, Time.TIME_SHORTER), email);
+        WebElement confirm = getWebElement(emailConfirmInput, Time.TIME_SHORTER);
+        if (isWebElementDisplayed(confirm)) {
+            clearAndTypeTextToWebElement(confirm, email);
+        }
+        return this;
+    }
+
+    public FacebookSignUpPage enterPassword(String password) {
+        clearAndTypeTextToWebElement(getWebElement(passwordInput, Time.TIME_SHORTER), password);
+        return this;
+    }
+
+    public FacebookSignUpPage selectBirthDate(String day, String month, String year) {
+        selectDropDownListOptionByText(getWebElement(birthDaySelect, Time.TIME_SHORTER), day);
+        selectDropDownListOptionByText(getWebElement(birthMonthSelect, Time.TIME_SHORTER), month);
+        selectDropDownListOptionByText(getWebElement(birthYearSelect, Time.TIME_SHORTER), year);
+        return this;
+    }
+
+    public FacebookSignUpPage selectGender(String gender) {
+        WebElement option;
+        gender = gender.toLowerCase();
+        switch (gender) {
+            case "female" -> option = getWebElement(femaleRadio, Time.TIME_SHORTER);
+            case "male" -> option = getWebElement(maleRadio, Time.TIME_SHORTER);
+            default -> option = getWebElement(customRadio, Time.TIME_SHORTER);
+        }
+        clickOnWebElement(option);
+        return this;
+    }
+
+    public void submitForm() {
+        clickOnWebElement(getWebElement(signUpButton, Time.TIME_SHORTER));
+    }
+}

--- a/src/test/java/tests/UI/FacebookCreateAccountTest.java
+++ b/src/test/java/tests/UI/FacebookCreateAccountTest.java
@@ -1,0 +1,61 @@
+package tests.UI;
+
+import data.Time;
+import org.openqa.selenium.WebDriver;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import pages.facebook.FacebookHomePage;
+import pages.facebook.FacebookSignUpPage;
+import utils.DateTimeUtils;
+import utils.LoggerUtils;
+
+public class FacebookCreateAccountTest extends BaseTestClass {
+
+    private WebDriver driver;
+    private final String sTestName = this.getClass().getName();
+    private FacebookHomePage facebookHomePage;
+    private FacebookSignUpPage facebookSignUpPage;
+
+    // Test data variables
+    private final String firstName = "Test";
+    private final String lastName = "User";
+    private final String email = "testuser" + System.currentTimeMillis() + "@example.com";
+    private final String password = "Password123!";
+    private final String birthDay = "10";
+    private final String birthMonth = "May";
+    private final String birthYear = "1990";
+    private final String gender = "Female";
+
+    @BeforeMethod
+    public void setUp(ITestContext testContext) {
+        driver = setUpMaxResolution();
+        testContext.setAttribute(sTestName + ".drivers", new WebDriver[]{driver});
+        facebookHomePage = new FacebookHomePage(driver);
+        facebookSignUpPage = new FacebookSignUpPage(driver);
+        facebookHomePage.open(true);
+        DateTimeUtils.wait(Time.TIME_SHORTER);
+        facebookHomePage.clickCreateNewAccount();
+        facebookSignUpPage.verifySignUpPage();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown(ITestResult result) {
+        LoggerUtils.log.debug("[END TEST] " + sTestName);
+        tearDown(driver, result);
+    }
+
+    @Test
+    public void testCreateAccountFlow() {
+        facebookSignUpPage.enterFirstName(firstName)
+                .enterLastName(lastName)
+                .enterEmail(email)
+                .enterPassword(password)
+                .selectBirthDate(birthDay, birthMonth, birthYear)
+                .selectGender(gender)
+                .submitForm();
+        // Additional verifications could be added here (e.g., check for success or error messages)
+    }
+}


### PR DESCRIPTION
## Summary
- add FacebookHomePage and FacebookSignUpPage page objects for reusable actions
- create FacebookCreateAccountTest using new pages for dynamic sign-up flow

## Testing
- `mvn -q -Dtest=FacebookCreateAccountTest -DfailIfNoTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688baf2f910c8323aed822fcd1fdf78f